### PR TITLE
fix(#26): React.memo に mediaMemoEqual 比較関数を追加しポーリング時の全件再レンダーを防止

### DIFF
--- a/frontend/__tests__/components/MediaThumb.test.tsx
+++ b/frontend/__tests__/components/MediaThumb.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import MediaThumb from '@/components/MediaThumb';
+import MediaThumb, { mediaMemoEqual, MediaThumbProps } from '@/components/MediaThumb';
 import { MediaResponse } from '@/lib/types';
 
 jest.mock('@/lib/api', () => ({
@@ -49,5 +49,109 @@ describe('MediaThumb – React.memo', () => {
     const before = container.firstChild;
     rerender(<MediaThumb media={media} selected={false} />);
     expect(container.firstChild).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mediaMemoEqual – 比較関数の直接テスト
+//
+// 設計メモ: `media.tags` は参照比較（===）を行うと API レスポンスごとに新配列が生成され
+// 常に false になるため comparator から除外している。
+// MediaThumb は現状 tags を表示しないため、表示上の影響もない。
+// 将来タグ表示を追加する場合は length + id の浅い比較を実装すること。
+// ---------------------------------------------------------------------------
+
+describe('mediaMemoEqual', () => {
+  function makeProps(
+    media: MediaResponse,
+    overrides: Partial<MediaThumbProps> = {}
+  ): MediaThumbProps {
+    return {
+      media,
+      selected: false,
+      selectMode: false,
+      size: 'large',
+      onSelect: undefined,
+      onClick: undefined,
+      ...overrides,
+    };
+  }
+
+  it('media 参照のみ変わり値は同じなら true（メモ化の主目的）', () => {
+    const a = makeMedia();
+    const b = { ...a }; // 同じ値、別参照
+    expect(mediaMemoEqual(makeProps(a), makeProps(b))).toBe(true);
+  });
+
+  it('id が変わったら false', () => {
+    expect(mediaMemoEqual(makeProps(makeMedia({ id: 1 })), makeProps(makeMedia({ id: 2 })))).toBe(false);
+  });
+
+  it('clip_status が変わったら false（pending バッジの再レンダーに必要）', () => {
+    expect(mediaMemoEqual(
+      makeProps(makeMedia({ clip_status: 'pending' })),
+      makeProps(makeMedia({ clip_status: 'done' }))
+    )).toBe(false);
+  });
+
+  it('original_filename が変わったら false', () => {
+    expect(mediaMemoEqual(
+      makeProps(makeMedia({ original_filename: 'a.jpg' })),
+      makeProps(makeMedia({ original_filename: 'b.jpg' }))
+    )).toBe(false);
+  });
+
+  it('media_type が変わったら false', () => {
+    expect(mediaMemoEqual(
+      makeProps(makeMedia({ media_type: 'image' })),
+      makeProps(makeMedia({ media_type: 'video', original_filename: 'clip.mp4', minio_key: 'k/clip.mp4' }))
+    )).toBe(false);
+  });
+
+  it('deleted_at が変わったら false', () => {
+    expect(mediaMemoEqual(
+      makeProps(makeMedia({ deleted_at: null })),
+      makeProps(makeMedia({ deleted_at: '2024-01-01T00:00:00Z' }))
+    )).toBe(false);
+  });
+
+  it('selected が変わったら false', () => {
+    const media = makeMedia();
+    expect(mediaMemoEqual(makeProps(media, { selected: false }), makeProps(media, { selected: true }))).toBe(false);
+  });
+
+  it('selectMode が変わったら false', () => {
+    const media = makeMedia();
+    expect(mediaMemoEqual(makeProps(media, { selectMode: false }), makeProps(media, { selectMode: true }))).toBe(false);
+  });
+
+  it('size が変わったら false', () => {
+    const media = makeMedia();
+    expect(mediaMemoEqual(makeProps(media, { size: 'large' }), makeProps(media, { size: 'small' }))).toBe(false);
+  });
+
+  it('onSelect が変わったら false（陳腐化したコールバックを呼ばないための保険）', () => {
+    const media = makeMedia();
+    expect(mediaMemoEqual(
+      makeProps(media, { onSelect: () => {} }),
+      makeProps(media, { onSelect: () => {} }) // 別参照
+    )).toBe(false);
+  });
+
+  it('onClick が変わったら false（陳腐化したコールバックを呼ばないための保険）', () => {
+    const media = makeMedia();
+    expect(mediaMemoEqual(
+      makeProps(media, { onClick: () => {} }),
+      makeProps(media, { onClick: () => {} }) // 別参照
+    )).toBe(false);
+  });
+
+  it('onSelect 参照が同じなら true', () => {
+    const media = makeMedia();
+    const handler = jest.fn();
+    expect(mediaMemoEqual(
+      makeProps(media, { onSelect: handler }),
+      makeProps(media, { onSelect: handler })
+    )).toBe(true);
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useRef, useState, useCallback } from 'react';
 import { deleteMedia } from '@/lib/api';
 import { MediaResponse } from '@/lib/types';
 import { useFilterState } from '@/hooks/useFilterState';
@@ -45,9 +45,9 @@ export default function Home() {
     refreshTags();
   }
 
-  function handleOpen(media: MediaResponse) {
+  const handleOpen = useCallback((media: MediaResponse) => {
     setLightboxMedia(media);
-  }
+  }, []);
 
   const lightboxIndex = lightboxMedia
     ? items.findIndex((i) => i.id === lightboxMedia.id)

--- a/frontend/components/MediaThumb.tsx
+++ b/frontend/components/MediaThumb.tsx
@@ -4,13 +4,37 @@ import React, { useState } from 'react';
 import { MediaResponse } from '@/lib/types';
 import { getMediaFileUrl } from '@/lib/api';
 
-interface MediaThumbProps {
+export interface MediaThumbProps {
   media: MediaResponse;
   selected?: boolean;
   selectMode?: boolean;
   onSelect?: (id: number) => void;
   onClick?: (media: MediaResponse) => void;
   size?: 'large' | 'small';
+}
+
+// ⚠️ tags は参照比較（===）だと API レスポンスの度に新配列になり常に false になる。
+// MediaThumb は tags を表示しないため comparator から除外している。
+// 将来タグ表示を追加する際は length + id の浅い比較に変更すること。
+//
+// ⚠️ onClick/onSelect は useCallback で安定化した参照を渡すこと。
+// Gallery から onClick={(m) => ...} のようなインラインを渡すと常に再レンダーになるため禁止。
+export function mediaMemoEqual(
+  prev: MediaThumbProps,
+  next: MediaThumbProps
+): boolean {
+  return (
+    prev.media.id                === next.media.id                &&
+    prev.media.clip_status       === next.media.clip_status       &&
+    prev.media.original_filename === next.media.original_filename &&
+    prev.media.media_type        === next.media.media_type        &&
+    prev.media.deleted_at        === next.media.deleted_at        &&
+    prev.selected                === next.selected                &&
+    prev.selectMode              === next.selectMode              &&
+    prev.size                    === next.size                    &&
+    prev.onSelect                === next.onSelect                &&
+    prev.onClick                 === next.onClick
+  );
 }
 
 export default React.memo(function MediaThumb({
@@ -160,4 +184,4 @@ export default React.memo(function MediaThumb({
       )}
     </div>
   );
-});
+}, mediaMemoEqual);

--- a/frontend/hooks/useMediaFetch.ts
+++ b/frontend/hooks/useMediaFetch.ts
@@ -119,9 +119,8 @@ export function useMediaFetch(
           .filter((r): r is PromiseFulfilledResult<MediaResponse> => r.status === 'fulfilled')
           .map((r) => r.value);
         if (updates.length > 0) {
-          setItems((prev) =>
-            prev.map((item) => updates.find((u) => u.id === item.id) ?? item)
-          );
+          const updateMap = new Map(updates.map((u) => [u.id, u]));
+          setItems((prev) => prev.map((item) => updateMap.get(item.id) ?? item));
           const anyCompleted = updates.some(
             (u) => u.clip_status !== 'pending' && u.clip_status !== 'running'
           );


### PR DESCRIPTION
## 概要

closes #26

ポーリング（5秒ごとの `setItems`）で `items` 配列が再生成されると各 `media` オブジェクトの参照が変わり、`React.memo` のデフォルト浅い比較が全件 `false` を返して全件再レンダーが発生していた問題を修正。

## 変更内容

### `frontend/components/MediaThumb.tsx`
- `mediaMemoEqual` 比較関数を追加し `React.memo` の第2引数に指定
- 比較フィールド: `id` / `clip_status` / `original_filename` / `media_type` / `deleted_at` / `selected` / `selectMode` / `size` / `onSelect` / `onClick`
- `tags` は除外（API レスポンスごとに新配列が生成され参照比較が常に `false` になるため。MediaThumb は tags を表示しないため表示上も影響なし。コメントで明記）
- `MediaThumbProps` をエクスポート（テストから利用）
- インラインコールバック禁止の注意コメントを追加

### `frontend/app/page.tsx`
- `handleOpen` を `useCallback` でラップし onClick 参照を安定化
  - これがないと `mediaMemoEqual` の `onClick` 比較が毎レンダーで `false` になりメモ化が効かない
- `useCallback` を import に追加

### `frontend/hooks/useMediaFetch.ts`
- ポーリング `setItems` 内の `updates.find` を `Map<number, MediaResponse>` に変更し O(n²) → O(n) に改善

### `frontend/__tests__/components/MediaThumb.test.tsx`
- `mediaMemoEqual` の直接ユニットテストを追加（12ケース）
  - 参照変化・各フィールド変化で正しく `true` / `false` を返すことを確認
  - describe 冒頭に `tags` 除外の設計コメントを明示
  - `onClick` / `onSelect` テストにコールバック陳腐化防止の意図コメントを記載

## テスト

```
npm run lint   # エラーなし（既存 warning のみ）
npm test       # 13 suites / 136 tests すべてグリーン
```

## スコープ外（別 PR）

- `docker-compose.test.yml` への `frontend-test` サービス追加（CI に jest ジョブが既存のため不要）