### PR TITLE
docs: README タイトルを MinIO Media API に修正、アーキテクチャ図に data/ を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MinIO Image API
+# MinIO Media API
 
 MinIO・PostgreSQL・FastAPI を使用した画像・動画アップロード API。CLIP による自動タグ付け機能を提供する。
 
@@ -189,6 +189,7 @@ docker compose --env-file .env.test -f docker-compose.test.yml down -v
 │  │  ├── schemas.py     (Pydantic スキーマ)          │  │
 │  │  ├── crud.py        (CRUD 操作)                  │  │
 │  │  ├── validators.py  (バリデーション)             │  │
+│  │  ├── data/          (初期データ)                 │  │
 │  │  ├── routers/       (エンドポイント)             │  │
 │  │  └── services/      (外部サービス連携)           │  │
 │  └───────────────────────────────────────────────────┘  │


### PR DESCRIPTION
## 変更内容

- タイトルを `MinIO Image API` → `MinIO Media API` に修正（リポジトリ名・実態に合わせる）
- アーキテクチャ図の `app/` 配下に `data/（初期データ）` を追記