### PR TITLE
fix: useLayoutEffect で fetchMediaRef の更新レースを修正 (#24)

### DIFF
--- a/frontend/__tests__/api-routes.test.ts
+++ b/frontend/__tests__/api-routes.test.ts
@@ -1,3 +1,4 @@
+export {};
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 

--- a/frontend/__tests__/hooks/useMediaFetch.test.ts
+++ b/frontend/__tests__/hooks/useMediaFetch.test.ts
@@ -187,7 +187,7 @@ describe('useMediaFetch - inflightRef ガード', () => {
     const firstFetch = new Promise((r) => { resolve = r; });
     mockGetMediaList.mockReturnValueOnce(firstFetch);
 
-    const { result } = renderUseMediaFetch();
+    renderUseMediaFetch();
     // 1st fetch が発火するまで待つ（useEffect は Promise.resolve 経由で非同期）
     await waitFor(() => expect(mockGetMediaList).toHaveBeenCalledTimes(1));
 
@@ -311,5 +311,57 @@ describe('useMediaFetch - ポーリング', () => {
     expect(mockGetMedia).toHaveBeenCalledWith(2);
     // クラッシュせず id=2 が still present
     expect(result.current.items.some((i) => i.id === 2)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #24: fetchMediaRef レース対策（useIsomorphicLayoutEffect）
+// ---------------------------------------------------------------------------
+// 注意: @testing-library/react は act() 内で useLayoutEffect・useEffect を
+// 両方フラッシュするため、Jest 環境ではタイミングの差（レース再現）は検証不可能。
+// このテストは「フィルタ変更後に IntersectionObserver が発火したとき
+// 最新フィルタ条件で API が呼ばれる」パラメータ整合性チェックを行う補助テスト。
+// レース条件の主検証は E2E (filters.spec.ts) で行う。
+describe('useMediaFetch - Issue #24 fetchMediaRef レース対策', () => {
+  it('フィルタ変更後に IntersectionObserver が発火しても最新フィルタ条件で fetch される', async () => {
+    // フィルタ A: mediaType='' (全件)
+    mockGetMediaList.mockResolvedValue({ items: [makeMedia(1)], total: 100 });
+
+    const sentinelRef = { current: document.createElement('div') };
+    const { result, rerender } = renderHook(
+      (filter) => useMediaFetch(filter, sentinelRef as React.RefObject<HTMLDivElement>),
+      { initialProps: defaultFilter }
+    );
+
+    // 初回ロード完了を確認
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    const callsAfterInit = mockGetMediaList.mock.calls.length;
+
+    // フィルタ B: mediaType='image' に変更（act 内で useLayoutEffect + useEffect 両方フラッシュ）
+    mockGetMediaList.mockResolvedValue({ items: [makeMedia(2)], total: 50 });
+    await act(async () => {
+      rerender({ ...defaultFilter, mediaType: 'image' });
+      await Promise.resolve();
+    });
+
+    // IntersectionObserver コールバックを即座に発火（フィルタ変更後の scroll を模倣）
+    await act(async () => {
+      lastIntersectionCallback?.([{ isIntersecting: true }]);
+      await Promise.resolve();
+    });
+
+    // 少なくともフィルタ B の条件（media_type='image'）で API が呼ばれていること
+    const newCalls = mockGetMediaList.mock.calls.slice(callsAfterInit);
+    expect(newCalls.length).toBeGreaterThanOrEqual(1);
+    const hasNewFilterCall = newCalls.some(
+      (args) => args[0]?.media_type === 'image'
+    );
+    expect(hasNewFilterCall).toBe(true);
+
+    // 旧フィルタ条件（media_type なし）+ offset > 0 のリクエストが存在しないこと
+    const staleCall = newCalls.find(
+      (args) => !args[0]?.media_type && (args[0]?.offset ?? 0) > 0
+    );
+    expect(staleCall).toBeUndefined();
   });
 });

--- a/frontend/__tests__/lib/api.test.ts
+++ b/frontend/__tests__/lib/api.test.ts
@@ -3,6 +3,7 @@
  * fetch はすべてモック。実際のネットワーク通信は行わない。
  */
 
+export {};
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 

--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -315,3 +315,100 @@ test.describe('ソート機能', () => {
     expect(firstFilenames).toEqual(expectedOrder);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #24: フィルタ変更直後スクロール競合テスト
+// ---------------------------------------------------------------------------
+// page.route() で /api/media をモックし has_more: true を返す。
+// seed データ 5件 < LIMIT 50 では通常 hasMore=false だが、モックにより
+// 無限スクロールが有効になりレース条件を再現できる。
+// 主検証: フィルタ変更直後にスクロールしても旧条件リクエスト（旧フィルタ + offset>0）が出ないこと。
+test.describe('フィルタ変更直後スクロール競合テスト (#24)', () => {
+  // モック用の最小完全データ
+  const FAKE_ITEM = {
+    id: 9001,
+    original_filename: 'mock-image.jpg',
+    media_type: 'image',
+    minio_key: 'test/mock-image.jpg',
+    created_at: '2024-01-01T00:00:00Z',
+    deleted_at: null,
+    tags: [],
+    clip_status: 'done',
+  };
+
+  test('フィルタ変更直後にスクロールしても旧条件リクエストが出ない', async ({ page }) => {
+    // /api/media（一覧）をモック:
+    // - フィルタなし (offset+limit < 100): has_more: true → IntersectionObserver を有効化しレース条件を再現
+    // - media_type=image: has_more: false → フィルタ変更後は追加スクロールを発生させず networkidle に収束させる
+    await page.route('**/api/media**', async (route) => {
+      // 個別メディア取得（/api/media/123）はスルー
+      if (route.request().url().match(/\/api\/media\/\d+/)) {
+        return route.continue();
+      }
+      const params = new URLSearchParams(new URL(route.request().url()).search);
+      const offset = parseInt(params.get('offset') || '0');
+      const limit = parseInt(params.get('limit') || '50');
+      const mediaType = params.get('media_type');
+      // フィルタ変更後（media_type=image）は has_more: false にして無限スクロールを止める
+      const hasMore = !mediaType && offset + limit < 100;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [FAKE_ITEM],
+          total: hasMore ? 100 : 1,
+          has_more: hasMore,
+        }),
+      });
+    });
+
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="media-type-select"]');
+
+    // フィルタ変更後のリクエストのみ収集
+    const postFilterRequests: { offset: number; mediaType: string | null }[] = [];
+    let collecting = false;
+    page.on('request', (req) => {
+      if (!collecting) return;
+      const url = req.url();
+      if (url.includes('/api/media') && !url.match(/\/api\/media\/\d+/)) {
+        const p = new URLSearchParams(new URL(url).search);
+        postFilterRequests.push({
+          offset: parseInt(p.get('offset') || '0'),
+          mediaType: p.get('media_type'),
+        });
+      }
+    });
+
+    // フィルタを変更し直後にスクロール（レース誘発）
+    // waitForRequest は selectOption より前に設定する（Playwright のパターン）
+    const imageFilterRequestPromise = page.waitForRequest((req) =>
+      req.url().includes('/api/media') &&
+      req.url().includes('media_type=image') &&
+      !req.url().match(/\/api\/media\/\d+/)
+    );
+
+    collecting = true;
+    await page.locator('[data-testid="media-type-select"]').selectOption('image');
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // フィルタ変更後の media_type=image リクエストを待機
+    await imageFilterRequestPromise;
+
+    // 観測ウィンドウ: 最初のリクエスト到達直後に遅れて発火する旧条件リクエストも収集できるよう
+    // networkidle まで待機してから検証する。これにより「少し遅れた offset>0 旧条件リクエスト」を取りこぼさない。
+    await page.waitForLoadState('networkidle');
+
+    // 検証1: フィルタ変更後に media_type=image + offset=0 のリクエストが ≥1 回あること（テスト意図の明示）
+    const initialFilterRequests = postFilterRequests.filter(
+      (r) => r.mediaType === 'image' && r.offset === 0
+    );
+    expect(initialFilterRequests.length).toBeGreaterThanOrEqual(1);
+
+    // 検証2: フィルタ変更後のリクエストに「旧条件（media_type なし）+ offset > 0」が存在しないこと
+    const staleRequests = postFilterRequests.filter(
+      (r) => r.offset > 0 && !r.mediaType
+    );
+    expect(staleRequests).toHaveLength(0);
+  });
+});

--- a/frontend/hooks/useIsomorphicLayoutEffect.ts
+++ b/frontend/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,8 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+// SSR（Next.js サーバーサイドレンダリング）では useLayoutEffect が React の warning を出す。
+// typeof window チェックによりブラウザ環境では useLayoutEffect、SSR 環境では useEffect にフォールバックする。
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;

--- a/frontend/hooks/useMediaFetch.ts
+++ b/frontend/hooks/useMediaFetch.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, RefObject } from 'react';
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 import { MediaResponse, TagResponse } from '@/lib/types';
 import { getMediaList, getMedia, getTags } from '@/lib/api';
 
@@ -79,8 +80,12 @@ export function useMediaFetch(
     refreshTags();
   }, [refreshTags]);
 
-  // Keep fetchMediaRef up-to-date so IntersectionObserver always calls the latest version
-  useEffect(() => {
+  // useIsomorphicLayoutEffect で描画前に ref を同期更新する。
+  // useEffect だとフィルタ変更後の React コミット〜useEffect 実行の間に
+  // IntersectionObserver が発火し、旧 fetchMedia（旧フィルタ条件）が呼ばれるレースがある。
+  // useLayoutEffect はコミット直後（ペイント前）に同期実行されるためこの競合を排除できる。
+  // SSR 安全性のため useIsomorphicLayoutEffect を使用する（Issue #24）。
+  useIsomorphicLayoutEffect(() => {
     fetchMediaRef.current = fetchMedia;
   }, [fetchMedia]);
 


### PR DESCRIPTION
## 概要

フィルタ変更後の React コミット〜`useEffect` 実行の間に IntersectionObserver が発火すると
旧 `fetchMedia`（旧フィルタ条件）が呼ばれる競合を修正。

**原因**: `useEffect(() => { fetchMediaRef.current = fetchMedia; }, [fetchMedia])` はペイント後に実行されるため、コミット〜useEffect の間にスクロールが発生すると旧フィルタ条件で fetch が走る。

**修正**: `useIsomorphicLayoutEffect`（ブラウザ = `useLayoutEffect`、SSR = `useEffect`）に変更し、コミット直後（ペイント前）に ref を同期更新してレースを排除。

## 変更内容

| ファイル | 内容 |
|---|---|
| `hooks/useIsomorphicLayoutEffect.ts` | 新規: SSR 安全な layoutEffect ユーティリティ |
| `hooks/useMediaFetch.ts` | `useEffect` → `useIsomorphicLayoutEffect`（1行変更） |
| `__tests__/hooks/useMediaFetch.test.ts` | パラメータ整合性テスト追加（補助）、未使用変数修正 |
| `__tests__/api-routes.test.ts` | `export {};` 追加で `tsc` TS2451 解消 |
| `__tests__/lib/api.test.ts` | `export {};` 追加で `tsc` TS2451 解消 |
| `e2e/filters.spec.ts` | フィルタ変更直後スクロール競合テスト追加（主検証） |

## テスト

- **Jest**: 137/137 ✅（`tsc --noEmit` 0 errors、lint 0 errors）
- **E2E**: 27/27 ✅（`page.route()` で `has_more: true` をモック → フィルタ変更直後スクロールで旧条件リクエストが出ないことを確認）

Closes #24