### PR TITLE
test: E2E false green を解消する (#39)

### DIFF
--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -39,14 +39,17 @@ test.describe('メディアタイプフィルタ', () => {
 
   test('「画像」を選択すると画像のみ表示される', async ({ page }) => {
     const select = page.locator('[data-testid="media-type-select"]');
-    const beforeCount = await page.locator('img').count();
+
+    const imageRequestPromise = page.waitForRequest((req) =>
+      req.url().includes('/api/media') &&
+      req.url().includes('media_type=image') &&
+      !req.url().match(/\/api\/media\/\d+/)
+    );
 
     await select.selectOption('image');
-    await page.waitForTimeout(1000);
-
-    const afterCount = await page.locator('img').count();
-    expect(afterCount).toBeGreaterThanOrEqual(0);
-    expect(afterCount).toBeLessThanOrEqual(beforeCount);
+    const req = await imageRequestPromise;
+    expect(req.url()).toContain('media_type=image');
+    await expect(select).toHaveValue('image');
   });
 
   test('「動画」を選択するとアイテム数が変わる', async ({ page }) => {
@@ -164,16 +167,19 @@ test.describe('タグフィルタポップアップ', () => {
 
   test('タグがあればポップアップボタンが表示される', async ({ page }) => {
     const filterBtn = page.locator('[data-testid="tag-filter-btn"]');
-    // タグなしDBでは表示されない場合もOK
-    const hasBtn = await filterBtn.count();
-    if (hasBtn > 0) {
-      await expect(filterBtn).toBeVisible();
+    if (await filterBtn.count() === 0) {
+      test.skip(true, 'タグフィルターボタンが存在しないためスキップ（seedでタグが存在することを前提とすべき）');
+      return;
     }
+    await expect(filterBtn).toBeVisible();
   });
 
   test('ポップアップが開閉できる（タグがあれば）', async ({ page }) => {
     const filterBtn = page.locator('[data-testid="tag-filter-btn"]');
-    if (await filterBtn.count() === 0) return;
+    if (await filterBtn.count() === 0) {
+      test.skip(true, 'タグフィルターボタンが存在しないためスキップ（seedでタグが存在することを前提とすべき）');
+      return;
+    }
 
     await filterBtn.click();
     await expect(page.locator('[data-testid="tag-filter-popup"]')).toBeVisible();
@@ -186,32 +192,44 @@ test.describe('タグフィルタポップアップ', () => {
 
   test('タグを選択するとボタンに選択数が表示される（タグがあれば）', async ({ page }) => {
     const filterBtn = page.locator('[data-testid="tag-filter-btn"]');
-    if (await filterBtn.count() === 0) return;
+    if (await filterBtn.count() === 0) {
+      test.skip(true, 'タグフィルターボタンが存在しないためスキップ（seedでタグが存在することを前提とすべき）');
+      return;
+    }
 
     await filterBtn.click();
     const firstOption = page.locator('[data-testid^="tag-option-"]').first();
-    if (await firstOption.count() > 0) {
-      await firstOption.locator('input[type="checkbox"]').check();
-      await expect(filterBtn).toContainText('(1)');
+    if (await firstOption.count() === 0) {
+      test.skip(true, 'タグオプションが存在しないためスキップ（seedでタグが存在することを前提とすべき）');
+      return;
     }
+    await firstOption.locator('input[type="checkbox"]').check();
+    await expect(filterBtn).toContainText('(1)');
   });
 
   test('クリアボタンでタグ選択が解除される（タグがあれば）', async ({ page }) => {
     const filterBtn = page.locator('[data-testid="tag-filter-btn"]');
-    if (await filterBtn.count() === 0) return;
+    if (await filterBtn.count() === 0) {
+      test.skip(true, 'タグフィルターボタンが存在しないためスキップ（seedでタグが存在することを前提とすべき）');
+      return;
+    }
 
     // タグを選択してからクリア
     await filterBtn.click();
     const firstOption = page.locator('[data-testid^="tag-option-"]').first();
-    if (await firstOption.count() > 0) {
-      await firstOption.locator('input[type="checkbox"]').check();
-      await page.mouse.click(10, 10); // close popup
-      const clearBtn = page.locator('[data-testid="tag-filter-clear-btn"]');
-      if (await clearBtn.count() > 0) {
-        await clearBtn.click();
-        await expect(filterBtn).not.toContainText('(');
-      }
+    if (await firstOption.count() === 0) {
+      test.skip(true, 'タグオプションが存在しないためスキップ（seedでタグが存在することを前提とすべき）');
+      return;
     }
+    await firstOption.locator('input[type="checkbox"]').check();
+    await page.mouse.click(10, 10); // close popup
+    const clearBtn = page.locator('[data-testid="tag-filter-clear-btn"]');
+    if (await clearBtn.count() === 0) {
+      test.skip(true, 'タグフィルタークリアボタンが存在しないためスキップ');
+      return;
+    }
+    await clearBtn.click();
+    await expect(filterBtn).not.toContainText('(');
   });
 });
 

--- a/frontend/e2e/upload-clip.spec.ts
+++ b/frontend/e2e/upload-clip.spec.ts
@@ -79,11 +79,51 @@ test.describe('アップロード → 非同期CLIP', () => {
     expect(analyzeData.clip_status).toBe('done');
   });
 
-  test('CLIPタグはデフォルト語彙から生成されて新規DBタグが作られる', async ({ request }) => {
-    const tagsRes = await request.get('/api/tags');
-    expect(tagsRes.ok()).toBeTruthy();
-    const tags = await tagsRes.json();
-    expect(tags.length).toBeGreaterThanOrEqual(0);
+  test('analyze結果のclipタグがDBに反映される', async ({ request }) => {
+    // 未解析の画像を探す（clip_status !== 'done'）
+    const listRes = await request.get('/api/media?limit=50');
+    expect(listRes.ok()).toBeTruthy();
+    const listData = await listRes.json();
+
+    const pendingImage = listData.items.find(
+      (item: { media_type: string; clip_status: string }) =>
+        item.media_type === 'image' && item.clip_status !== 'done'
+    );
+    if (!pendingImage) {
+      test.skip(true, '未解析の画像が存在しないためスキップ');
+      return;
+    }
+
+    // analyze前: このメディアのCLIPタグIDを記録（未解析なので空のはず）
+    const beforeMediaRes = await request.get(`/api/media/${pendingImage.id}`);
+    expect(beforeMediaRes.ok()).toBeTruthy();
+    const beforeMedia = await beforeMediaRes.json();
+    const beforeClipIds = new Set(
+      (beforeMedia.tags ?? [])
+        .filter((t: { source: string }) => t.source === 'clip')
+        .map((t: { id: number }) => t.id)
+    );
+
+    // analyze実行
+    const analyzeRes = await request.post(`/api/media/${pendingImage.id}/analyze`, { data: {} });
+    expect(analyzeRes.ok()).toBeTruthy();
+    const analyzeData = await analyzeRes.json();
+
+    // analyzeレスポンスにCLIPタグが含まれること
+    const responseClipTags: Array<{ id: number; source: string }> = analyzeData.tags.filter(
+      (t: { source: string }) => t.source === 'clip'
+    );
+    expect(responseClipTags.length).toBeGreaterThan(0);
+
+    // analyze後: このメディアを再取得し、CLIPタグが追加されたことを確認（因果検証）
+    const afterMediaRes = await request.get(`/api/media/${pendingImage.id}`);
+    expect(afterMediaRes.ok()).toBeTruthy();
+    const afterMedia = await afterMediaRes.json();
+    const newClipTagsForMedia = (afterMedia.tags ?? []).filter(
+      (t: { source: string; id: number }) =>
+        t.source === 'clip' && !beforeClipIds.has(t.id)
+    );
+    expect(newClipTagsForMedia.length).toBeGreaterThan(0);
   });
 
   test('CLIP ANALYZEボタンがライトボックスに表示される', async ({ page }) => {
@@ -104,7 +144,10 @@ test.describe('アップロード → 非同期CLIP', () => {
     // まずmediaIdを取得
     const listRes = await request.get('/api/media?limit=1');
     const listData = await listRes.json();
-    if (listData.total === 0) return;
+    if (listData.total === 0) {
+      test.skip(true, 'メディアが存在しないためスキップ');
+      return;
+    }
     const mediaId = listData.items[0].id;
 
     const analyzeBtn = page.getByRole('button', { name: /CLIP ANALYZE/i });
@@ -123,9 +166,8 @@ test.describe('アップロード → 非同期CLIP', () => {
 
     // APIでclip_status確認
     const mediaRes = await request.get(`/api/media/${mediaId}`);
-    if (mediaRes.ok()) {
-      const mediaData = await mediaRes.json();
-      expect(mediaData.clip_status).toBe('done');
-    }
+    expect(mediaRes.ok()).toBeTruthy();
+    const mediaData = await mediaRes.json();
+    expect(mediaData.clip_status).toBe('done');
   });
 });


### PR DESCRIPTION
## 概要
Issue #39 で報告された「常に真のアサーション」と「早期 return による silent pass」を全箇所修正。

## 変更内容

### filters.spec.ts

| 行 | 種別 | 修正内容 |
|---|---|---|
| :48 | 常に真アサーション | `toBeGreaterThanOrEqual(0)` を削除し `waitForRequest` で `media_type=image` のリクエスト発行 + select 値を検証 |
| :168 | silent pass | `if (hasBtn > 0) { expect }` → `count===0` なら `test.skip` |
| :176, :189, :201 | 早期 return | `if (...) return;` → `test.skip(true, '理由')` + `return` |
| :202, :218 | silent pass | `if (firstOption.count() > 0) { アサーション }` → count=0 なら `test.skip` |
| :222 | silent pass | `if (clearBtn.count() > 0) { アサーション }` → count=0 なら `test.skip` |

### upload-clip.spec.ts

| 行 | 種別 | 修正内容 |
|---|---|---|
| :82 | 常に真アサーション + 弱い検証 | テスト名を「analyze結果のclipタグがDBに反映される」に変更。`clip_status!=='done'` の未解析メディアを探して `/api/media/{id}` の before/after clip タグ差分で因果検証 |
| :107 | 早期 return | `if (listData.total === 0) return;` → `test.skip(true, '...')` |
| :168 | silent pass | `if (mediaRes.ok()) { expect }` → `expect(mediaRes.ok()).toBeTruthy()` 先置き |

## 受け入れ条件（Issue #39）
- [x] 常に真のアサーションが解消される
- [x] 前提不足時は pass ではなく skip として観測できる
- [x] analyze の因果検証（メディア固有タグの before/after diff）

Closes #39