### PR TITLE
test: E2E の絶対パス依存を相対解決へ変更する (#34)

### DIFF
--- a/frontend/e2e/upload-clip.spec.ts
+++ b/frontend/e2e/upload-clip.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import * as path from 'path';
 
-const TEST_IMAGE = '/Users/kangju/program/minio-image-api/frontend/public/test-image.jpg';
+const TEST_IMAGE_CANDIDATES = [
+  path.join(__dirname, '..', 'public', 'test-image.jpg'),
+  path.join(__dirname, '..', 'public', 'favicon.ico'),
+];
 
 // テストはシリアル実行
 test.describe.configure({ mode: 'serial' });
@@ -12,14 +16,10 @@ test.describe('アップロード → 非同期CLIP', () => {
     await page.waitForLoadState('networkidle');
 
     // テスト用画像がなければスキップ
-    let testFile = TEST_IMAGE;
-    if (!fs.existsSync(testFile)) {
-      // public/favicon.icoでも可
-      testFile = '/Users/kangju/program/minio-image-api/frontend/public/favicon.ico';
-      if (!fs.existsSync(testFile)) {
-        test.skip(true, 'テスト用ファイルが見つからないためスキップ');
-        return;
-      }
+    const testFile = TEST_IMAGE_CANDIDATES.find((f) => fs.existsSync(f));
+    if (!testFile) {
+      test.skip(true, 'テスト用ファイルが見つからないためスキップ');
+      return;
     }
 
     await page.getByRole('button', { name: 'UPLOAD' }).click();


### PR DESCRIPTION
## 概要
Issue #34 で報告されたローカル絶対パス依存を解消し、CI・他環境でも同じ spec が実行できるようにする。

## 変更内容

### frontend/e2e/upload-clip.spec.ts

- `import * as path from 'path'` を追加
- `TEST_IMAGE` の `/Users/kangju/...` 絶対パス（2箇所）を削除
- `global-setup.ts` と同じ **candidates + `path.join(__dirname, '..', 'public', ...)`** パターンに統一
- ネストした `if` チェックを `find()` + 単一 `test.skip` に簡略化

```ts
// 変更前
const TEST_IMAGE = '/Users/kangju/program/minio-image-api/frontend/public/test-image.jpg';

// 変更後
const TEST_IMAGE_CANDIDATES = [
  path.join(__dirname, '..', 'public', 'test-image.jpg'),
  path.join(__dirname, '..', 'public', 'favicon.ico'),
];
```

## 確認事項
- [x] `rg '/Users/' frontend/e2e` で残存絶対パスなし
- [x] Docker E2E 環境で `upload-clip.spec.ts` 6/6 pass 確認

## 受け入れ条件（Issue #34）
- [x] `/Users/...` 文字列が `frontend/e2e` から消える
- [x] ローカル/CI で同じ spec が同じ条件で実行できる
- [x] 不要な skip が減る

Closes #34