### PR TITLE
fix(e2e): waitForTimeout・networkidle を全スペックから除去し安定待機に統一

### DIFF
--- a/frontend/e2e/bulk-upload.spec.ts
+++ b/frontend/e2e/bulk-upload.spec.ts
@@ -35,7 +35,7 @@ for i in range(100):
     test.setTimeout(300_000);
 
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'UPLOAD' }).waitFor({ timeout: 15_000 });
 
     // アップロード前のメディア件数を取得
     const beforeRes = await request.get('http://localhost:3000/api/media?limit=1');
@@ -52,10 +52,9 @@ for i in range(100):
       page.locator('text=ファイルをドロップ、またはクリックして選択').click(),
     ]);
     await fileChooser.setFiles(testFiles);
-    await page.waitForTimeout(1_000);
-
     // UPLOAD ボタン押下
     const uploadBtn = page.getByRole('button', { name: /^UPLOAD/ }).last();
+    await expect(uploadBtn).toBeEnabled();
     await uploadBtn.click();
 
     // モーダルが閉じるまで待機（アップロード完了、最大 120 秒）

--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -18,7 +18,7 @@ const mediaApiResponse = (
 test.describe('フィルターパネル表示', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('img', { timeout: 15_000 });
+    await page.locator('[data-testid="media-type-select"]').waitFor({ timeout: 15_000 });
   });
 
   test('フィルターパネルが表示される', async ({ page }) => {
@@ -49,7 +49,7 @@ test.describe('フィルターパネル表示', () => {
 test.describe('メディアタイプフィルタ', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('img', { timeout: 15_000 });
+    await page.locator('[data-testid="media-type-select"]').waitFor({ timeout: 15_000 });
   });
 
   test('「画像」を選択すると画像のみ表示される', async ({ page }) => {
@@ -78,6 +78,8 @@ test.describe('メディアタイプフィルタ', () => {
 
   test('「すべて」に戻すと全件表示', async ({ page }) => {
     const select = page.locator('[data-testid="media-type-select"]');
+    // 初期メディア一覧の描画を待ってからベースライン件数を取得（0件環境はタイムアウトを無視）
+    await page.locator('img').first().waitFor({ timeout: 10_000 }).catch(() => {});
     const beforeCount = await page.locator('img').count();
 
     await Promise.all([
@@ -97,7 +99,7 @@ test.describe('メディアタイプフィルタ', () => {
 test.describe('削除済み含むフィルタ', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('img', { timeout: 15_000 });
+    await page.locator('[data-testid="media-type-select"]').waitFor({ timeout: 15_000 });
   });
 
   test('チェックをONにするとAPIが include_deleted=true で呼ばれる', async ({ page }) => {
@@ -129,7 +131,7 @@ test.describe('削除済み含むフィルタ', () => {
 test.describe('作成日フィルタ', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('img', { timeout: 15_000 });
+    await page.locator('[data-testid="media-type-select"]').waitFor({ timeout: 15_000 });
   });
 
   test('未来日付の created_from を設定すると0件になる', async ({ page }) => {
@@ -173,7 +175,7 @@ test.describe('作成日フィルタ', () => {
 test.describe('フィルターリセット', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('img', { timeout: 15_000 });
+    await page.locator('[data-testid="media-type-select"]').waitFor({ timeout: 15_000 });
   });
 
   test('リセットボタンで全フィルターがクリアされる', async ({ page }) => {
@@ -203,7 +205,7 @@ test.describe('フィルターリセット', () => {
 test.describe('タグフィルタポップアップ', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('img', { timeout: 15_000 });
+    await page.locator('[data-testid="media-type-select"]').waitFor({ timeout: 15_000 });
   });
 
   test('タグがあればポップアップボタンが表示される', async ({ page }) => {
@@ -276,7 +278,7 @@ test.describe('タグフィルタポップアップ', () => {
 test.describe('ナビゲーション（ギャラリーからタグページ）', () => {
   test('TAGSリンクでタグページに移動できる', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'UPLOAD' }).waitFor({ timeout: 15_000 });
     await page.locator('a', { hasText: 'TAGS' }).click();
     await page.waitForURL('/tags');
     await expect(page).toHaveURL('/tags');
@@ -287,7 +289,7 @@ test.describe('ナビゲーション（ギャラリーからタグページ）',
 test.describe('ソート機能', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('img', { timeout: 15_000 });
+    await page.locator('[data-testid="media-type-select"]').waitFor({ timeout: 15_000 });
   });
 
   test('ソートフィールドセレクトが表示される', async ({ page }) => {
@@ -342,10 +344,20 @@ test.describe('ソート機能', () => {
       mediaApiResponse(page, (u) => u.searchParams.get('sort_by') === 'created_at'),
       sortBySelect.selectOption('created_at'),
     ]);
-    const [finalRes] = await Promise.all([
-      mediaApiResponse(page, (u) => u.searchParams.get('sort_by') === 'original_filename'),
+    const [step3Request] = await Promise.all([
+      page.waitForRequest((req) => {
+        if (req.url().match(/\/api\/media\/\d+/)) return false;
+        const url = new URL(req.url());
+        return (
+          url.pathname === '/api/media' &&
+          req.method() === 'GET' &&
+          url.searchParams.get('sort_by') === 'original_filename'
+        );
+      }),
       sortBySelect.selectOption('original_filename'),
     ]);
+    const finalRes = await step3Request.response();
+    expect(finalRes).not.toBeNull();
 
     // 最終選択値が反映されていることを確認
     await expect(sortBySelect).toHaveValue('original_filename');
@@ -359,7 +371,7 @@ test.describe('ソート機能', () => {
     // DOM と API が一致しない場合、競合レスポンスによる表示順崩れを検知できる。
 
     // レスポンスから先頭ファイル名を取得し、DOM の再レンダリング完了を待機する
-    const finalData = await finalRes.json();
+    const finalData = await finalRes!.json();
     const firstExpectedFilename: string | undefined = finalData.items[0]?.original_filename;
     if (firstExpectedFilename) {
       await expect(page.locator('[data-filename]').first()).toHaveAttribute(
@@ -457,16 +469,17 @@ test.describe('フィルタ変更直後スクロール競合テスト (#24)', ()
       req.url().includes('media_type=image') &&
       !req.url().match(/\/api\/media\/\d+/)
     );
+    const imageFilterResponsePromise = mediaApiResponse(
+      page, (u) => u.searchParams.get('media_type') === 'image'
+    );
 
     collecting = true;
     await page.locator('[data-testid="media-type-select"]').selectOption('image');
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
-    // フィルタ変更後の media_type=image リクエストを待機
+    // フィルタ変更後の media_type=image リクエスト・レスポンスを待機
     await imageFilterRequestPromise;
-
-    // 遅れて発火する旧条件リクエストも収集できるよう、フィルタ変更後のレスポンスを待機してから検証する
-    await mediaApiResponse(page, (u) => u.searchParams.get('media_type') === 'image');
+    await imageFilterResponsePromise;
 
     // 検証1: フィルタ変更後に media_type=image + offset=0 のリクエストが ≥1 回あること（テスト意図の明示）
     const initialFilterRequests = postFilterRequests.filter(

--- a/frontend/e2e/gallery.spec.ts
+++ b/frontend/e2e/gallery.spec.ts
@@ -91,7 +91,18 @@ test.describe('無限スクロール', () => {
     const before = await page.locator('img').count();
 
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-    await page.waitForTimeout(2000);
+    await page.waitForResponse(
+      (res) => {
+        const url = new URL(res.url());
+        return (
+          url.pathname === '/api/media' &&
+          res.request().method() === 'GET' &&
+          res.ok() &&
+          parseInt(url.searchParams.get('offset') || '0') > 0
+        );
+      },
+      { timeout: 3_000 }
+    ).catch(() => {});
 
     const after = await page.locator('img').count();
     expect(after).toBeGreaterThanOrEqual(before);
@@ -152,7 +163,6 @@ test.describe('SELECT モード', () => {
   test('SELECT ボタンでセレクトモードになる', async ({ page }) => {
     await page.getByRole('button', { name: 'SELECT', exact: true }).click();
     await page.locator('img').first().click();
-    await page.waitForTimeout(500);
     await expect(page.getByRole('button', { name: /DELETE SELECTED/i })).toBeVisible();
   });
 
@@ -167,7 +177,6 @@ test.describe('SELECT モード', () => {
     const selectAllBtn = page.getByRole('button', { name: /SELECT ALL/i });
     if (await selectAllBtn.count() > 0) {
       await selectAllBtn.click();
-      await page.waitForTimeout(500);
       // DELETE SELECTED が表示される（何かが選択されている）
       await expect(page.getByRole('button', { name: /DELETE SELECTED/i })).toBeVisible();
     }

--- a/frontend/e2e/tags.spec.ts
+++ b/frontend/e2e/tags.spec.ts
@@ -1,9 +1,24 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+
+const tagsListResponse = (page: Page) =>
+  page.waitForResponse((res) => {
+    const url = new URL(res.url());
+    return url.pathname === '/api/tags' && res.request().method() === 'GET' && res.ok();
+  });
+
+const tagsMutateResponse = (page: Page, method: 'POST' | 'PATCH' | 'DELETE', okOnly = true) =>
+  page.waitForResponse((res) => {
+    const url = new URL(res.url());
+    return (
+      url.pathname.startsWith('/api/tags') &&
+      res.request().method() === method &&
+      (okOnly ? res.ok() : true)
+    );
+  });
 
 test.describe('タグ管理ページ基本表示', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/tags');
-    await page.waitForLoadState('networkidle');
+    await Promise.all([tagsListResponse(page), page.goto('/tags')]);
   });
 
   test('TAGSページが表示される', async ({ page }) => {
@@ -40,21 +55,21 @@ test.describe('タグ CRUD 操作', () => {
   const renamedTagName = `e2e-tag-renamed-${Date.now()}`;
 
   test('新規タグを作成できる', async ({ page }) => {
-    await page.goto('/tags');
-    await page.waitForLoadState('networkidle');
+    await Promise.all([tagsListResponse(page), page.goto('/tags')]);
 
     const input = page.locator('[data-testid="new-tag-input"]');
     await input.fill(testTagName);
-    await page.locator('[data-testid="add-tag-btn"]').click();
+    await Promise.all([
+      tagsMutateResponse(page, 'POST'),
+      page.locator('[data-testid="add-tag-btn"]').click(),
+    ]);
 
     // 作成後にタグが一覧に現れる
-    await page.waitForTimeout(1000);
     await expect(page.locator(`text=${testTagName}`)).toBeVisible();
   });
 
   test('作成したタグを編集できる', async ({ page }) => {
-    await page.goto('/tags');
-    await page.waitForLoadState('networkidle');
+    await Promise.all([tagsListResponse(page), page.goto('/tags')]);
 
     // 対象タグの行を探す
     const rows = page.locator('[data-testid^="tag-row-"]');
@@ -75,8 +90,10 @@ test.describe('タグ CRUD 操作', () => {
 
         // 保存
         const saveBtns = page.locator('[data-testid^="save-tag-btn-"]');
-        await saveBtns.first().click();
-        await page.waitForTimeout(1000);
+        await Promise.all([
+          tagsMutateResponse(page, 'PATCH'),
+          saveBtns.first().click(),
+        ]);
 
         await expect(page.locator(`text=${renamedTagName}`)).toBeVisible();
         break;
@@ -85,8 +102,7 @@ test.describe('タグ CRUD 操作', () => {
   });
 
   test('空名でタグを作成しようとするとエラー', async ({ page }) => {
-    await page.goto('/tags');
-    await page.waitForLoadState('networkidle');
+    await Promise.all([tagsListResponse(page), page.goto('/tags')]);
 
     const addBtn = page.locator('[data-testid="add-tag-btn"]');
     // 入力なしでボタンが無効になっているか確認
@@ -95,8 +111,7 @@ test.describe('タグ CRUD 操作', () => {
   });
 
   test('作成したタグを削除できる', async ({ page }) => {
-    await page.goto('/tags');
-    await page.waitForLoadState('networkidle');
+    await Promise.all([tagsListResponse(page), page.goto('/tags')]);
 
     // renamedTagName または testTagName を削除
     const rows = page.locator('[data-testid^="tag-row-"]');
@@ -111,8 +126,10 @@ test.describe('タグ CRUD 操作', () => {
 
         // confirm ダイアログを受け入れる
         page.on('dialog', (dialog) => dialog.accept());
-        await deleteBtn.click();
-        await page.waitForTimeout(1000);
+        await Promise.all([
+          tagsMutateResponse(page, 'DELETE'),
+          deleteBtn.click(),
+        ]);
 
         // タグが消えていることを確認
         await expect(page.locator(`text=${renamedTagName}`)).not.toBeVisible();
@@ -122,20 +139,23 @@ test.describe('タグ CRUD 操作', () => {
   });
 
   test('同名タグを作成するとエラーメッセージが出る', async ({ page }) => {
-    await page.goto('/tags');
-    await page.waitForLoadState('networkidle');
+    await Promise.all([tagsListResponse(page), page.goto('/tags')]);
 
     // まず1つ作成
     const dupTagName = `e2e-dup-${Date.now()}`;
     const input = page.locator('[data-testid="new-tag-input"]');
     await input.fill(dupTagName);
-    await page.locator('[data-testid="add-tag-btn"]').click();
-    await page.waitForTimeout(1000);
+    await Promise.all([
+      tagsMutateResponse(page, 'POST'),
+      page.locator('[data-testid="add-tag-btn"]').click(),
+    ]);
 
     // 同名を再度作成
     await input.fill(dupTagName);
-    await page.locator('[data-testid="add-tag-btn"]').click();
-    await page.waitForTimeout(1000);
+    await Promise.all([
+      tagsMutateResponse(page, 'POST', false),
+      page.locator('[data-testid="add-tag-btn"]').click(),
+    ]);
 
     // エラーメッセージが表示される
     await expect(page.locator('[data-testid="error-message"]').or(
@@ -151,8 +171,10 @@ test.describe('タグ CRUD 操作', () => {
       if (text?.includes(dupTagName)) {
         const deleteBtns = page.locator('[data-testid^="delete-tag-btn-"]');
         page.on('dialog', (dialog) => dialog.accept());
-        await deleteBtns.nth(i).click();
-        await page.waitForTimeout(500);
+        await Promise.all([
+          tagsMutateResponse(page, 'DELETE'),
+          deleteBtns.nth(i).click(),
+        ]);
         break;
       }
     }
@@ -161,8 +183,7 @@ test.describe('タグ CRUD 操作', () => {
 
 test.describe('ヘッダーナビゲーション（TAGSページから）', () => {
   test('GALLERYリンクでギャラリーに移動できる', async ({ page }) => {
-    await page.goto('/tags');
-    await page.waitForLoadState('networkidle');
+    await Promise.all([tagsListResponse(page), page.goto('/tags')]);
     // HeaderのGALLERYリンクをクリック
     await page.locator('a', { hasText: 'GALLERY' }).click();
     await page.waitForURL('/');

--- a/frontend/e2e/upload-clip.spec.ts
+++ b/frontend/e2e/upload-clip.spec.ts
@@ -13,7 +13,7 @@ test.describe.configure({ mode: 'serial' });
 test.describe('アップロード → 非同期CLIP', () => {
   test('アップロードするとモーダルがすぐに閉じる', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'UPLOAD' }).waitFor({ timeout: 15_000 });
 
     // テスト用画像がなければスキップ
     const testFile = TEST_IMAGE_CANDIDATES.find((f) => fs.existsSync(f));
@@ -30,9 +30,9 @@ test.describe('アップロード → 非同期CLIP', () => {
       page.locator('text=ファイルをドロップ、またはクリックして選択').click(),
     ]);
     await fileChooser.setFiles(testFile);
-    await page.waitForTimeout(500);
-
     const uploadBtn = page.getByRole('button', { name: /^UPLOAD/ }).last();
+    await expect(uploadBtn).toBeEnabled();
+
     await uploadBtn.click();
 
     // 旧：CLIPが完了するまで待機（最大90秒）が不要に
@@ -161,8 +161,6 @@ test.describe('アップロード → 非同期CLIP', () => {
       },
       { timeout: 90_000 }
     ).catch(() => {});
-
-    await page.waitForTimeout(1000);
 
     // APIでclip_status確認
     const mediaRes = await request.get(`/api/media/${mediaId}`);

--- a/frontend/e2e/worker-flow.spec.ts
+++ b/frontend/e2e/worker-flow.spec.ts
@@ -32,7 +32,7 @@ open('${testFilePath}', 'wb').write(buf.getvalue())
 
   test('アップロード直後は clip_status が pending になる', async ({ page, request }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'UPLOAD' }).waitFor({ timeout: 15_000 });
 
     await page.getByRole('button', { name: 'UPLOAD' }).click();
     await page.waitForSelector('text=UPLOAD MEDIA');
@@ -42,9 +42,9 @@ open('${testFilePath}', 'wb').write(buf.getvalue())
       page.locator('text=ファイルをドロップ、またはクリックして選択').click(),
     ]);
     await fileChooser.setFiles(testFilePath);
-    await page.waitForTimeout(500);
-
     const uploadBtn = page.getByRole('button', { name: /^UPLOAD/ }).last();
+    await expect(uploadBtn).toBeEnabled();
+
     await uploadBtn.click();
 
     // モーダルが閉じるまで待機（20秒以内）


### PR DESCRIPTION
## 概要

E2E テスト全スペックから `waitForTimeout` と `waitForLoadState('networkidle')` を除去し、イベント駆動待機に統一する。

Closes #30

---

## 変更内容

### filters.spec.ts
- `networkidle` → `UPLOAD button.waitFor()`
- `waitForSelector('img')` → `[data-testid="media-type-select"]`.waitFor() (データ0件環境の回帰修正)
- 「すべてに戻す」テスト: `img.first().waitFor().catch()` でベースライン計測前の待機を追加
- レースコンディション修正: `imageFilterResponsePromise` をアクション前に設定
- 連続ソート step3: `waitForRequest` + `request.response()` + `expect(finalRes).not.toBeNull()` でステールレスポンス対策

### tags.spec.ts
- ヘルパー追加: `tagsListResponse(page)` / `tagsMutateResponse(page, method, okOnly?)`
- 7x `networkidle` → `Promise.all([tagsListResponse, page.goto('/tags')])`
- 5x `waitForTimeout` → `Promise.all([tagsMutateResponse(method), click])`

### gallery.spec.ts
- 無限スクロール `waitForTimeout(2000)` → `waitForResponse(offset>0, {timeout:3000}).catch()`
- SELECT 後 `waitForTimeout(500)` × 2 → 削除（後続 `expect(...).toBeVisible()` が待機）

### upload-clip.spec.ts
- `networkidle` → `UPLOAD button.waitFor()`
- `waitForTimeout(500)` → `expect(uploadBtn).toBeEnabled()`
- `waitForTimeout(1000)`（waitForFunction 後の冗長待機）→ 削除

### worker-flow.spec.ts / bulk-upload.spec.ts
- `networkidle` → `UPLOAD button.waitFor()`
- `waitForTimeout` → `expect(uploadBtn).toBeEnabled()`

---

## 検証

```
npx playwright test e2e/filters.spec.ts --repeat-each=3
→ 69 passed / 12 skipped / 0 failed

npx playwright test --repeat-each=3
→ 190 passed（既存の既知失敗のみ: #46 #47 #48 #49）
```

## 関連 Issue
- #46 bulk-upload CLIP タイムアウト（別途対応）
- #47 worker-flow タイムアウト設定ミス（別途対応）
- #48 upload-clip データ状態依存フレーキー（別途対応）
- #49 filters 高負荷時フレーキー（別途対応）