### PR TITLE
fix(e2e): [#47] worker-flow テストタイムアウトとURLハードコード問題を修正

### DIFF
--- a/frontend/e2e/worker-flow.spec.ts
+++ b/frontend/e2e/worker-flow.spec.ts
@@ -13,6 +13,7 @@ import { execSync } from 'child_process';
 test.describe('clip-worker 非同期解析フロー', () => {
   let tmpDir: string;
   let testFilePath: string;
+  let uploadedMediaId: number | null = null;
 
   test.beforeAll(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'worker-test-'));
@@ -51,19 +52,21 @@ open('${testFilePath}', 'wb').write(buf.getvalue())
     await page.waitForSelector('text=UPLOAD MEDIA', { state: 'hidden', timeout: 20_000 });
 
     // 最新のメディアを取得して clip_status を確認
-    const listRes = await request.get('http://localhost:3000/api/media?limit=1');
+    const listRes = await request.get('/api/media?limit=1');
     expect(listRes.ok()).toBeTruthy();
     const listData = await listRes.json();
     expect(listData.total).toBeGreaterThan(0);
 
     const latestMedia = listData.items[0];
+    uploadedMediaId = latestMedia.id;
     // アップロード直後は pending か running（worker が処理中の可能性）
     expect(['pending', 'running', 'done']).toContain(latestMedia.clip_status);
   });
 
   test('clip-worker が 60 秒以内に CLIP 解析を完了する', async ({ request }) => {
+    test.setTimeout(90_000);
     // 最新のメディアが done になるまでポーリング
-    const listRes = await request.get('http://localhost:3000/api/media?limit=1');
+    const listRes = await request.get('/api/media?limit=1');
     expect(listRes.ok()).toBeTruthy();
     const listData = await listRes.json();
 
@@ -72,10 +75,10 @@ open('${testFilePath}', 'wb').write(buf.getvalue())
       return;
     }
 
-    const mediaId = listData.items[0].id;
+    const mediaId = uploadedMediaId ?? listData.items[0].id;
 
     await expect.poll(async () => {
-      const res = await request.get(`http://localhost:3000/api/media/${mediaId}`);
+      const res = await request.get(`/api/media/${mediaId}`);
       if (!res.ok()) return 'error';
       const data = await res.json();
       return data.clip_status;


### PR DESCRIPTION
## 概要

Closes #47

## 変更内容

### 1. `test.setTimeout(90_000)` を追加
テストのグローバルタイムアウト（30s）が `expect.poll` のタイムアウト（60s）より短く、常にテストが失敗していた問題を修正。
90s = expect.poll 60s + バッファ 30s

### 2. `uploadedMediaId` をdescribeスコープで共有
test 1 がアップロードしたmediaIdをtest 2 に正確に引き継ぐ。
`?limit=1` に頼る場合、並行テストや既存データで意図しないアイテムを参照する可能性があったため。

### 3. ハードコードされた `http://localhost:3000` を相対パスに変更
`PW_BASE_URL` の設定（隔離テスト環境）が有効になるよう、絶対URLを相対パスに変更。
これにより `docker-compose.test.yml` の隔離E2E環境でも正しく動作する。

## テスト実行方法

隔離E2E環境での実行（推奨）:
```bash
docker compose --env-file .env.test -f docker-compose.test.yml up -d api-server-test frontend-e2e clip-worker-e2e
cd frontend && PW_BASE_URL=http://localhost:3001 npx playwright test e2e/worker-flow.spec.ts
docker compose --env-file .env.test -f docker-compose.test.yml down -v
```

## 確認結果

隔離環境で exit code 0 を確認。